### PR TITLE
[update]レート制限の追加 #279

### DIFF
--- a/backend/routes/web.php
+++ b/backend/routes/web.php
@@ -86,7 +86,7 @@ Route::prefix('settings')->name('settings.')->middleware('auth')->group(function
 });
 
 # NEWS API関連機能
-Route::prefix('news')->name('news.')->middleware('auth')->group(function () {
+Route::prefix('news')->name('news.')->middleware('auth', 'throttle:30,1')->group(function () {
     Route::get('/headline/default', 'NEWSAPI\HeadlineNewsController@defaultIndex')->name('default_index');
     Route::post('/headline/custom', 'NEWSAPI\HeadlineNewsController@customIndex')->name('custom_index');
     Route::get('/covid/default', 'NEWSAPI\CovidNewsController@defaultIndex')->name('covid_default_index');


### PR DESCRIPTION
利用している外部APIに1日あたりのアクセス数制限があるため、ユーザーのリクエスト回数に制限を追加